### PR TITLE
initial onreadystatechange value in node vs a browser

### DIFF
--- a/XMLHttpRequest.js
+++ b/XMLHttpRequest.js
@@ -54,7 +54,7 @@ exports.XMLHttpRequest = function() {
 	this.readyState = this.UNSENT;
 
 	// default ready state change handler in case one is not set or is set late
-	this.onreadystatechange = function() {};
+	this.onreadystatechange = null;
 
 	// Result & response
 	this.responseText = "";
@@ -255,6 +255,8 @@ exports.XMLHttpRequest = function() {
 	 */
 	var setState = function(state) {
 		self.readyState = state;
-		self.onreadystatechange();
+		if (typeof self.onreadystatechange === "function") {
+			self.onreadystatechange();
+		}
 	}
 };


### PR DESCRIPTION
Hi,

In some browser implementations (notably Firefox/Chrome/Opera) onreadystatechange is initially null, here it is set as an empty function. (https://github.com/driverdan/node-XMLHttpRequest/blob/master/XMLHttpRequest.js#L57)

This threw me off when iterating over object properties/functions (typeof checks), so I forked and pushed a commit that fixes things for us.

If you happen to find this change desirable for the main project, feel free to pull in (or cancel the request). It's a small change so I don't _believe_ it should cause any issues (I quickly ran the tests but some seemed to fail regardless?).  Thanks for the open code and work! :-)

Cheers,
