### PR TITLE
documented require should use lowercase (modulename)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This can be used with JS designed for browsers to improve reuse of code and allo
 ## Usage ##
 Here's how to include the module in your project and use as the browser-based XHR object.
 
-	var XMLHttpRequest = require("XMLHttpRequest").XMLHttpRequest;
+	var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 	var xhr = new XMLHttpRequest();
 
 Refer to [W3C specs](http://www.w3.org/TR/XMLHttpRequest/) for XHR methods.


### PR DESCRIPTION
Hi dan,

just a small change (that cost us a lot of nerves :). When requiring per npm, the require name needs to match the module name and not the name of the file. Using CamelCase works fine on osx because it doesn't discriminate capitalization, but on linux, the module can't be found.

Thanks for your work on xmlrequest! Cheers,
   -tim
