### PR TITLE
Bug fix: Host header bad setted

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -275,7 +275,7 @@ exports.XMLHttpRequest = function() {
     var uri = url.pathname + (url.search ? url.search : '');
 
     // Set the Host header or the server may reject the request
-    headers["Host"] = host;
+    headers["Host"] = host + ':' + url.port;
 
     // Set Basic Auth if necessary
     if (settings.user) {


### PR DESCRIPTION
If the user is requesting a server using any port but 80, the
response from the server will have a wrong Location header, so the
client won't be able to use it.

According to the RFC the Host header is composed of hostname:port

Cheers,
Miguel
