### PR TITLE
Exposing "Set-Cookie" header from getAllResponseHeaders()

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -50,8 +50,6 @@ exports.XMLHttpRequest = function() {
     "connection",
     "content-length",
     "content-transfer-encoding",
-    "cookie",
-    "cookie2",
     "date",
     "expect",
     "host",
@@ -214,10 +212,7 @@ exports.XMLHttpRequest = function() {
     var result = "";
 
     for (var i in response.headers) {
-      // Cookie headers are excluded
-      if (i !== "set-cookie" && i !== "set-cookie2") {
-        result += i + ": " + response.headers[i] + "\r\n";
-      }
+      result += i + ": " + response.headers[i] + "\r\n";
     }
     return result.substr(0, result.length - 2);
   };

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -13,10 +13,6 @@ var server = http.createServer(function (req, res) {
   res.writeHead(200, {
     "Content-Type": "text/plain",
     "Content-Length": Buffer.byteLength(body),
-    // Set cookie headers to see if they're correctly suppressed
-    // Actual values don't matter
-    "Set-Cookie": "foo=bar",
-    "Set-Cookie2": "bar=baz",
     "Connection": "close"
   });
   res.write("Hello World");


### PR DESCRIPTION
Set-Cookie header should be returned from the function, so that a Server acting as a Client can form it's requests correctly (REST).

Use case: Client API consumer that requires a Server session
