### PR TITLE
added support for 302, 303, 307 redirects

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -383,7 +383,7 @@ exports.XMLHttpRequest = function() {
 
         response = resp;
 
-      	if(response.statusCode === 302){
+      	if(response.statusCode === 302 || response.statusCode === 307 || response.statusCode === 303){
           settings.url = response.headers['location']
           var url = Url.parse(settings.url);
           host = url.hostname
@@ -391,7 +391,7 @@ exports.XMLHttpRequest = function() {
             hostname: url.hostname,
             port: url.port,
             path: url.path,
-            method: settings.method,
+            method: response.statusCode === 303 ? 'GET' : settings.method,
             headers: headers
           }
 

--- a/tests/test-redirect-302.js
+++ b/tests/test-redirect-302.js
@@ -1,0 +1,42 @@
+var sys = require("util")
+  , assert = require("assert")
+  , XMLHttpRequest = require("../lib/XMLHttpRequest").XMLHttpRequest
+  , xhr = new XMLHttpRequest()
+  , http = require("http");
+
+// Test server
+var server = http.createServer(function (req, res) {
+
+  if(req.url === '/redirectingResource'){
+    res.writeHead(302, {'Location': 'http://localhost:8000/'})
+    res.end()
+    return
+  }
+
+  var body = "Hello World";
+  res.writeHead(200, {
+    "Content-Type": "text/plain",
+    "Content-Length": Buffer.byteLength(body),
+    "Date": "Thu, 30 Aug 2012 18:17:53 GMT",
+    "Connection": "close"
+  });
+  res.write("Hello World");
+  res.end();
+
+  this.close();
+}).listen(8000);
+
+xhr.onreadystatechange = function() {
+  if (this.readyState == 4) {
+  	assert.equal(xhr.getRequestHeader('Location'), '')
+  	assert.equal(xhr.responseText, "Hello World")
+    sys.puts("done");
+  }
+};
+
+try {
+  xhr.open("GET", "http://localhost:8000/redirectingResource");
+  xhr.send();
+} catch(e) {
+  console.log("ERROR: Exception raised", e);
+}

--- a/tests/test-redirect-303.js
+++ b/tests/test-redirect-303.js
@@ -1,0 +1,42 @@
+var sys = require("util")
+  , assert = require("assert")
+  , XMLHttpRequest = require("../lib/XMLHttpRequest").XMLHttpRequest
+  , xhr = new XMLHttpRequest()
+  , http = require("http");
+
+// Test server
+var server = http.createServer(function (req, res) {
+
+  if(req.url === '/redirectingResource'){
+    res.writeHead(303, {'Location': 'http://localhost:8000/'})
+    res.end()
+    return
+  }
+
+  var body = "Hello World";
+  res.writeHead(200, {
+    "Content-Type": "text/plain",
+    "Content-Length": Buffer.byteLength(body),
+    "Date": "Thu, 30 Aug 2012 18:17:53 GMT",
+    "Connection": "close"
+  });
+  res.write("Hello World");
+  res.end();
+
+  this.close();
+}).listen(8000);
+
+xhr.onreadystatechange = function() {
+  if (this.readyState == 4) {
+  	assert.equal(xhr.getRequestHeader('Location'), '')
+  	assert.equal(xhr.responseText, "Hello World")
+    sys.puts("done");
+  }
+};
+
+try {
+  xhr.open("POST", "http://localhost:8000/redirectingResource");
+  xhr.send();
+} catch(e) {
+  console.log("ERROR: Exception raised", e);
+}

--- a/tests/test-redirect-307.js
+++ b/tests/test-redirect-307.js
@@ -1,0 +1,44 @@
+var sys = require("util")
+  , assert = require("assert")
+  , XMLHttpRequest = require("../lib/XMLHttpRequest").XMLHttpRequest
+  , xhr = new XMLHttpRequest()
+  , http = require("http");
+
+// Test server
+var server = http.createServer(function (req, res) {
+
+  if(req.url === '/redirectingResource'){
+    res.writeHead(307, {'Location': 'http://localhost:8000/'})
+    res.end()
+    return
+  }
+  
+  assert.equal(req.method, 'POST')
+
+  var body = "Hello World";
+  res.writeHead(200, {
+    "Content-Type": "text/plain",
+    "Content-Length": Buffer.byteLength(body),
+    "Date": "Thu, 30 Aug 2012 18:17:53 GMT",
+    "Connection": "close"
+  });
+  res.write("Hello World");
+  res.end();
+
+  this.close();
+}).listen(8000);
+
+xhr.onreadystatechange = function() {
+  if (this.readyState == 4) {
+  	assert.equal(xhr.getRequestHeader('Location'), '')
+  	assert.equal(xhr.responseText, "Hello World")
+    sys.puts("done");
+  }
+};
+
+try {
+  xhr.open("POST", "http://localhost:8000/redirectingResource");
+  xhr.send();
+} catch(e) {
+  console.log("ERROR: Exception raised", e);
+}


### PR DESCRIPTION
I'm not sure I'm updating the internal state correctly - but it works for simple cases at least.  XHR requests are automatically/transparently redirected by the browser so I needed this for compatibility node-side.

Thanks for the great module!

Liam
