### PR TITLE
Remove max limit on connections per host

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -30,7 +30,7 @@ exports.XMLHttpRequest = function() {
 
   // Request settings
   var settings = {};
-  
+
   // Disable header blacklist.
   // Not part of XHR specs.
   var disableHeaderCheck = false;
@@ -360,7 +360,8 @@ exports.XMLHttpRequest = function() {
       port: port,
       path: uri,
       method: settings.method,
-      headers: headers
+      headers: headers,
+      agent: false
     };
 
     // Reset error flag


### PR DESCRIPTION
Disable agent on http requests to prevent connections from being subject to the default max limit on connections per host.

This has been documented since Node 0.6.0:

http://nodejs.org/docs/v0.6.0/api/http.html#http.request
http://nodejs.org/docs/v0.7.0/api/http.html#http.request
http://nodejs.org/docs/v0.8.0/api/http.html#http_http_request_options_callback
http://nodejs.org/docs/v0.9.0/api/http.html#http_http_request_options_callback

The interface is different in versions prior to 0.6.0 (but I'd assume that the option is ignored if set but unsupported):

http://nodejs.org/docs/v0.5.0/api/http.html#http.Agent
