### PR TITLE
Allow for Buffer instances as request bodies

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -344,7 +344,7 @@ exports.XMLHttpRequest = function() {
     if (settings.method === "GET" || settings.method === "HEAD") {
       data = null;
     } else if (data) {
-      headers["Content-Length"] = Buffer.byteLength(data);
+      headers["Content-Length"] = data.length || Buffer.byteLength(data);
 
       if (!headers["Content-Type"]) {
         headers["Content-Type"] = "text/plain;charset=UTF-8";


### PR DESCRIPTION
It's difficult to treat binary data as strings in Node (and it's not recommended).

This patch lets you safely pass buffers to `send()`.
