### PR TITLE
browser field for package.json

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,21 @@
+/// shim when packaged for the browser
+
+module.exports.XMLHttpRequest = function(xdomain) {
+  if (xdomain && 'undefined' != typeof XDomainRequest && !exports.ua.hasCORS) {
+    return new XDomainRequest();
+  }
+
+  // XMLHttpRequest can be disabled on IE
+  try {
+    if ('undefined' != typeof XMLHttpRequest && (!xdomain || exports.ua.hasCORS)) {
+      return new XMLHttpRequest();
+    }
+  } catch (e) { }
+
+  if (!xdomain) {
+    try {
+      return new ActiveXObject('Microsoft.XMLHTTP');
+    } catch(e) { }
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -24,4 +24,7 @@
   , "example": "./example"
   }
 , "main": "./lib/XMLHttpRequest.js"
+, "browser": {
+    "./lib/XMLHttpRequest.js": "./lib/browser.js"
+  }
 }


### PR DESCRIPTION
When packaging this module for client side delivery, the browser field
in package.json provides a hint to the package tool about which files to
replace with client targeted counterparts.

This is currently supported by the following bundle tool:
https://github.com/shtylman/node-script

And I hope to get wider adoption of this practice. The goal is to provide a sensible way for module authors to make their packages cross environment. npm modules have the cool property of being able to work in server and client environments and this eases the burden on consumers of your module (like engine.io). Since your module aims to replicate the browser side api on the server, the browser portion simply provides the xml request object.
