### PR TITLE
ENYO-1740: allow raw-data (Buffer) as a payload

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -344,7 +344,11 @@ exports.XMLHttpRequest = function() {
     if (settings.method === "GET" || settings.method === "HEAD") {
       data = null;
     } else if (data) {
-      headers["Content-Length"] = Buffer.byteLength(data);
+      if (Buffer.isBuffer(data)) {
+        headers["Content-Length"] = data.length;
+      } else {
+        headers["Content-Length"] = Buffer.byteLength(data);
+      }
 
       if (!headers["Content-Type"]) {
         headers["Content-Type"] = "text/plain;charset=UTF-8";


### PR DESCRIPTION
- Some web services do not support chunked encoding (HTTP streaming)
  with PUT.  Is this case, the client must set the Content-Length
  header.  The code as it was only supported a String payload, because
  Buffer.byteLength() only accepts a String as a parameter.
- New code accepts raw data. contained in a Buffer.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
