### PR TITLE
Fixed a couple lint warnings

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -24,7 +24,6 @@ exports.XMLHttpRequest = function() {
   var https = require('https');
 
   // Holds http.js objects
-  var client;
   var request;
   var response;
 
@@ -154,7 +153,6 @@ exports.XMLHttpRequest = function() {
     // Check for valid request method
     if (!isAllowedHttpMethod(method)) {
       throw "SecurityError: Request method not allowed";
-      return;
     }
 
     settings = {
@@ -176,7 +174,7 @@ exports.XMLHttpRequest = function() {
    */
   this.setDisableHeaderCheck = function(state) {
     disableHeaderCheck = state;
-  }
+  };
 
   /**
    * Sets a header for the request.
@@ -267,14 +265,14 @@ exports.XMLHttpRequest = function() {
 
     var ssl = false, local = false;
     var url = Url.parse(settings.url);
-
+    var host;
     // Determine the server
     switch (url.protocol) {
       case 'https:':
         ssl = true;
         // SSL & non-SSL both need host, no break here.
       case 'http:':
-        var host = url.hostname;
+        host = url.hostname;
         break;
 
       case 'file:':
@@ -283,7 +281,7 @@ exports.XMLHttpRequest = function() {
 
       case undefined:
       case '':
-        var host = "localhost";
+        host = "localhost";
         break;
 
       default:
@@ -446,7 +444,7 @@ exports.XMLHttpRequest = function() {
         + (data ? "req.write('" + data.replace(/'/g, "\\'") + "');":"")
         + "req.end();";
       // Start the other Node Process, executing this string
-      syncProc = spawn(process.argv[0], ["-e", execString]);
+      var syncProc = spawn(process.argv[0], ["-e", execString]);
       while((self.responseText = fs.readFileSync(syncFile, 'utf8')) == "") {
         // Wait while the file is empty
       }


### PR DESCRIPTION
- removed unused variable client
- removed unreachable 'return' after 'throw'
- added semicolon
- host was defined twice
- assigning to undeclared variable syncProc
