### PR TITLE
Fix race condition in synchronous requests

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -422,6 +422,7 @@ exports.XMLHttpRequest = function() {
       self.dispatchEvent("loadstart");
     } else { // Synchronous
       // Create a temporary file for communication with the other Node process
+      var contentFile = ".node-xmlhttprequest-content-" + process.pid;
       var syncFile = ".node-xmlhttprequest-sync-" + process.pid;
       fs.writeFileSync(syncFile, "", "utf8");
       // The async request the other Node process executes
@@ -432,28 +433,33 @@ exports.XMLHttpRequest = function() {
         + "var req = doRequest(options, function(response) {"
         + "response.setEncoding('utf8');"
         + "response.on('data', function(chunk) {"
-        + "responseText += chunk;"
+        + "  responseText += chunk;"
         + "});"
         + "response.on('end', function() {"
-        + "fs.writeFileSync('" + syncFile + "', 'NODE-XMLHTTPREQUEST-STATUS:' + response.statusCode + ',' + responseText, 'utf8');"
+        + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-STATUS:' + response.statusCode + ',' + responseText, 'utf8');"
+        + "fs.unlinkSync('" + syncFile + "');"
         + "});"
         + "response.on('error', function(error) {"
-        + "fs.writeFileSync('" + syncFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
+        + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
+        + "fs.unlinkSync('" + syncFile + "');"
         + "});"
         + "}).on('error', function(error) {"
-        + "fs.writeFileSync('" + syncFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
+        + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
+        + "fs.unlinkSync('" + syncFile + "');"
         + "});"
         + (data ? "req.write('" + data.replace(/'/g, "\\'") + "');":"")
         + "req.end();";
       // Start the other Node Process, executing this string
       syncProc = spawn(process.argv[0], ["-e", execString]);
-      while((self.responseText = fs.readFileSync(syncFile, 'utf8')) == "") {
-        // Wait while the file is empty
+      var statusText;
+      while(fs.existsSync(syncFile)) {
+        // Wait while the sync file is empty
       }
+      self.responseText = fs.readFileSync(contentFile, 'utf8');
       // Kill the child process once the file has data
       syncProc.stdin.end();
       // Remove the temporary file
-      fs.unlinkSync(syncFile);
+      fs.unlinkSync(contentFile);
       if (self.responseText.match(/^NODE-XMLHTTPREQUEST-ERROR:/)) {
         // If the file returned an error, handle it
         var errorObj = self.responseText.replace(/^NODE-XMLHTTPREQUEST-ERROR:/, "");


### PR DESCRIPTION
This resolves a race condition that can (and often does) result in truncated response text being returned for synchronous requests.

The reason this happens is that the busy loop in the main node process that monitors the output file stops as soon as it's non-empty. However, file writes are not guaranteed to be atomic, so the parent process may read the file while the child process is still writing to it, resulting in truncated output.

The fix is simple. Instead of monitoring the content of the output file, we create a separate empty sync file and monitor its existence. After the whole content has been written to the output file from the child process, we delete it, guaranteeing that the parent process won't try to access the content file until it's all written out.
