### PR TITLE
Allow `http.Agent` usage

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -15,7 +15,11 @@ var Url = require("url")
   , spawn = require("child_process").spawn
   , fs = require('fs');
 
-exports.XMLHttpRequest = function() {
+  /**
+   *
+   * @param http.Agent agent An http.Agent instance; http.globalAgent may be used; if 'undefined', agent usage is disabled; (optional)
+   */
+exports.XMLHttpRequest = function(agent) {
   /**
    * Private variables
    */
@@ -96,6 +100,8 @@ exports.XMLHttpRequest = function() {
   /**
    * Public vars
    */
+
+  this.agent = agent || false;
 
   // Current state
   this.readyState = this.UNSENT;
@@ -359,7 +365,7 @@ exports.XMLHttpRequest = function() {
       path: uri,
       method: settings.method,
       headers: headers,
-      agent: false
+      agent: this.agent
     };
 
     // Reset error flag


### PR DESCRIPTION
by passing in an `http.Agent` instance (either `http.globalAgent` or any custom instance) to the `XMLHttpRequest` constructor.

This addresses #44 and #48.

This is so that connections can be reused by the standard Http Keep-Alive mechanism, that is based on the `http.Agent.maxSockets` setting. Without agents, every request means a new TCP connections, behavior that differs from browser implementations of XHR.

One ramification of the former that made me implement this was that one TCP socket per HTTP request severely limits your ability to do load testing, as all your outbound ports get consumed in the `TIME_WAIT` state in no time. Try e.g. `socket-io-client` and the `xhr-polling` transport from node.js, which will use `node-XMLHttpRequest`, to verify.

Browser implementations of XHR on the other hand recycle their TCP sockets, otherwise socket-io based clients would bail as well in normal, non load-testing scenarios, when more than 16k events in 4 minutes are sent (the numbers highly depend on your OS and TCP settings).

**Implementation note**: It maintains backwards compatibility, in that if you don't pass in an agent, none will be used.

Ideally however, I'd like `http.globalAgent` to be the default, like it is with node's `http` requests, and like it was the case for `node-XMLHttpRequest` until changed by https://github.com/driverdan/node-XMLHttpRequest/commit/89586313be006873066dfd37465ac4f54c6819ab , which @guile also laments in #44. However, my patch maintains the current status quo.
