### PR TITLE
fix for backslashes in data not encoding correctly

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -477,7 +477,7 @@ exports.XMLHttpRequest = function() {
         + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
         + "fs.unlinkSync('" + syncFile + "');"
         + "});"
-        + (data ? "req.write('" + data.replace(/'/g, "\\'") + "');":"")
+        + (data ? "req.write('" + JSON.stringify(data).slice(1,-1).replace(/'/g, "\\'") + "');":"")
         + "req.end();";
       // Start the other Node Process, executing this string
       var syncProc = spawn(process.argv[0], ["-e", execString]);


### PR DESCRIPTION
when posting data that contains backslashes such as "\foo\nbar", it is not encoded correctly.
To fix this, I used JSON.stringify to create a valid string and then remove the first and last ticks with slice(1,-1), then perform your tick escape code.
