### PR TITLE
introduce support for http-streaming by not filtering multiple LOADING e...

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -582,7 +582,7 @@ exports.XMLHttpRequest = function() {
    * @param int state New state
    */
   var setState = function(state) {
-    if (self.readyState !== state) {
+    if (state == self.LOADING || self.readyState !== state) {
       self.readyState = state;
 
       if (settings.async || self.readyState < self.OPENED || self.readyState === self.DONE) {

--- a/tests/test-streaming.js
+++ b/tests/test-streaming.js
@@ -1,0 +1,71 @@
+var sys = require("util")
+  , assert = require("assert")
+  , http = require("http")
+  , XMLHttpRequest = require("../lib/XMLHttpRequest").XMLHttpRequest
+  , xhr;
+
+// Test server
+
+function completeResponse(res,server,body) {
+  res.end();
+  assert.equal(onreadystatechange, true);
+  assert.equal(readystatechange, true);
+  assert.equal(removed, true);
+  assert.equal(loadCount, body.length);
+  sys.puts("done");
+  server.close();
+}
+function push(res,piece) {
+  res.write(piece);
+}
+
+var server = http.createServer(function (req, res) {
+  var body = (req.method != "HEAD" ? ["Hello","World","Stream"] : []);
+
+  res.writeHead(200, {
+    "Content-Type": "text/plain",
+    "Content-Length": Buffer.byteLength(body.join(""))
+  });
+  
+  var nextPiece = 0;
+  var self = this;
+  var interval = setInterval(function() {
+    if (nextPiece < body.length) {
+      res.write(body[nextPiece]);
+      nextPiece++;
+    } else {
+      completeResponse(res,self,body);
+      clearInterval(interval);
+    }
+  },100); //nagle may put writes together, if it happens rise the interval time
+
+}).listen(8000);
+
+xhr = new XMLHttpRequest();
+
+// Track event calls
+var onreadystatechange = false;
+var readystatechange = false;
+var removed = true;
+var loadCount = 0;
+var removedEvent = function() {
+  removed = false;
+};
+
+xhr.onreadystatechange = function() {
+  onreadystatechange = true;
+};
+
+xhr.addEventListener("readystatechange", function() {
+  readystatechange = true;
+  if (xhr.readyState == xhr.LOADING) {
+    loadCount++;
+  }
+});
+
+// This isn't perfect, won't guarantee it was added in the first place
+xhr.addEventListener("readystatechange", removedEvent);
+xhr.removeEventListener("readystatechange", removedEvent);
+
+xhr.open("GET", "http://localhost:8000");
+xhr.send();


### PR DESCRIPTION
...vents following the first one.

Hi,

I noticed that multiple LOADING events were filtered out instead of being forwarded to listeners of onreadystatechange. 
I'm not actually sure the multiple "LOADING" event is part of the W3C specs but you can see it working on most browsers (at least Firefox Chrome Safari and IE starting from IE10)

e.g.: try this:

``` JavaScript
var XHRClass = typeof XMLHttpRequest != "undefined" ? XMLHttpRequest : require("xmlhttprequest").XMLHttpRequest;  
var xhr = new XHRClass();
xhr.onreadystatechange = function() {
  console.log("State: " + this.readyState);
};
xhr.open("GET", "http://push.lightstreamer.com/lightstreamer/create_session.js?LS_client_version=5.0&LS_adapter_set=DEMO&LS_keepalive_millis=1000");
xhr.send();
```

My pull request contains the very small fix and a test derived from test-events (I should have probably stripped more stuff from the original test, let me know if you want me to)

let me know your thoughts,
Bye.
