### PR TITLE
ensure self.status is always a number, not a string...

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -496,7 +496,7 @@ exports.XMLHttpRequest = function() {
         self.handleError(errorObj);
       } else {
         // If the file returned okay, parse its data and move to the DONE state
-        self.status = self.responseText.replace(/^NODE-XMLHTTPREQUEST-STATUS:([0-9]*),.*/, "$1");
+        self.status = parseInt(self.responseText.replace(/^NODE-XMLHTTPREQUEST-STATUS:([0-9]*),.*/, "$1"), 10);
         self.responseText = self.responseText.replace(/^NODE-XMLHTTPREQUEST-STATUS:[0-9]*,(.*)/, "$1");
         setState(self.DONE);
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xmlhttprequest"
 , "description": "XMLHttpRequest for Node"
-, "version": "1.5.0"
+, "version": "1.5.1"
 , "author": {
     "name": "Dan DeFelippi"
   , "url": "http://driverdan.com"


### PR DESCRIPTION
in porting some code to use node.js, i noticed that self.status got set to a string value for synchronous results...
