### PR TITLE
Properly escape backslash in sync post body

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -477,7 +477,7 @@ exports.XMLHttpRequest = function() {
         + "fs.writeFileSync('" + contentFile + "', 'NODE-XMLHTTPREQUEST-ERROR:' + JSON.stringify(error), 'utf8');"
         + "fs.unlinkSync('" + syncFile + "');"
         + "});"
-        + (data ? "req.write('" + data.replace(/'/g, "\\'") + "');":"")
+        + (data ? "req.write('" + data..replace(/\\/g, "\\\\").replace(/'/g, "\\'") + "');":"")
         + "req.end();";
       // Start the other Node Process, executing this string
       var syncProc = spawn(process.argv[0], ["-e", execString]);


### PR DESCRIPTION
If the body of a post contained a backslash, it would be treated as an escape character when written to res.write('\') and corrupts the contents of the body.  This patch properly escapes the backslash character.
