### PR TITLE
Adds browser-file/field in package.json.

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,0 +1,13 @@
+/**
+ * This code is only being used when compiled with tools, such as for example
+ * browserify, that respects the "browser"-field in package.json.
+ */
+
+/**
+ * The native XMLHttpRequest of the browser, if available. When in case this
+ * file is parsed this will replace the one from ./XMLHttpRequest.js.
+ *
+ * @type {XMLHttpRequest|null}
+ */
+exports.XMLHttpRequest =  window.XMLHttpRequest || null;
+

--- a/package.json
+++ b/package.json
@@ -24,4 +24,5 @@
   , "example": "./example"
   }
 , "main": "./lib/XMLHttpRequest.js"
+, "browser": "./lib/browser.js"
 }


### PR DESCRIPTION
  This commit adds the functionality of using the browsers implementation of
  XMLHttpRequest when this module is used in the browser. The browser-field in
  package.json points to the file which will be used if compiled with a tool
  that supports this feature.
  Really convenient if you're building stuff that will run in both server and
  browser environments.
