### PR TITLE
Added setTimeout for XMLHttpRequest

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -577,6 +577,14 @@ exports.XMLHttpRequest = function() {
   };
 
   /**
+   *Set request timeout in milliseconds with callback function.It's only valid in node.js environment.
+   */
+  this.setTimeout = function(timeout, cb){
+    if(request)
+        request.setTimeout(timeout, cb);
+  };
+
+  /**
    * Changes readyState and calls onreadystatechange.
    *
    * @param int state New state


### PR DESCRIPTION
We have  to set request timeout  in our production to avoid blocking too many requests.I added a method `setTimeout` for XMLHttpRequest.I hope it can be merged into master branch,then i don't have to use my own version of `node-XMLHttpRequest`.Thanks for your great work.
