### PR TITLE
Fix: Cannot read property 'headers' of undefined

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -205,6 +205,8 @@ exports.XMLHttpRequest = function() {
   this.getResponseHeader = function(header) {
     if (typeof header === "string"
       && this.readyState > this.OPENED
+      && response
+      && response.headers
       && response.headers[header.toLowerCase()]
       && !errorFlag
     ) {


### PR DESCRIPTION
Occasionally, you will get "Cannot read property 'headers' of undefined" when trying to request a header. It's randomly crashing my daemon - I assume when I get a null response from a server.

This does a couple of extra checks.
