### PR TITLE
created .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+example
+tests
+
+autotest.watchr


### PR DESCRIPTION
created `.npmignore` file to ignore `example` and `tests` folder as well as the `autotest.watchr` file for __production__