### PR TITLE
Allow auth with just username or just password

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -331,10 +331,10 @@ exports.XMLHttpRequest = function() {
 
     // Set Basic Auth if necessary
     if (settings.user || settings.password) {
-      if (typeof settings.user == "undefined") {
+      if (settings.user == null) {
         settings.user = "";
       }
-      if (typeof settings.password == "undefined") {
+      if (settings.password == null) {
         settings.password = "";
       }
       var authBuf = new Buffer(settings.user + ":" + settings.password);


### PR DESCRIPTION
This PR makes two changes:
1. You can make requests that require authentication with just a username (no password) or just a password (no username). This seems to be possible pretty much everywhere else (including browsers) and I couldn't find anything in W3C docs that say otherwise (please correct me if I'm wrong). The reason I put this in was to be able to use VLC's http interface that needs a password but with no username.
2. Originally, if no password was given, the password variable would be set to `null`. Later, it would be set to `""` if its type was `undefined`. Clearly the password is never `undefined` because the `typeof null` is `object`. Thus, with no password, your auth info would be "bob:null" instead of "bob:" as it should be. This was fixed and the same was done for usernames to make the first change work.
