### PR TITLE
throw errors not strings

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -152,7 +152,7 @@ exports.XMLHttpRequest = function() {
 
     // Check for valid request method
     if (!isAllowedHttpMethod(method)) {
-      throw "SecurityError: Request method not allowed";
+      throw new Error("SecurityError: Request method not allowed");
     }
 
     settings = {
@@ -184,14 +184,14 @@ exports.XMLHttpRequest = function() {
    */
   this.setRequestHeader = function(header, value) {
     if (this.readyState != this.OPENED) {
-      throw "INVALID_STATE_ERR: setRequestHeader can only be called when state is OPEN";
+      throw new Error("INVALID_STATE_ERR: setRequestHeader can only be called when state is OPEN");
     }
     if (!isAllowedHttpHeader(header)) {
       console.warn('Refused to set unsafe header "' + header + '"');
       return;
     }
     if (sendFlag) {
-      throw "INVALID_STATE_ERR: send flag is true";
+      throw new Error("INVALID_STATE_ERR: send flag is true");
     }
     headers[header] = value;
   };
@@ -258,11 +258,11 @@ exports.XMLHttpRequest = function() {
    */
   this.send = function(data) {
     if (this.readyState != this.OPENED) {
-      throw "INVALID_STATE_ERR: connection must be opened before send() is called";
+      throw new Error("INVALID_STATE_ERR: connection must be opened before send() is called");
     }
 
     if (sendFlag) {
-      throw "INVALID_STATE_ERR: send has already been called";
+      throw new Error("INVALID_STATE_ERR: send has already been called");
     }
 
     var ssl = false, local = false;
@@ -287,13 +287,13 @@ exports.XMLHttpRequest = function() {
         break;
 
       default:
-        throw "Protocol not supported.";
+        throw new Error("Protocol not supported.");
     }
 
     // Load files off the local filesystem (file://)
     if (local) {
       if (settings.method !== "GET") {
-        throw "XMLHttpRequest: Only GET method is supported";
+        throw new Error("XMLHttpRequest: Only GET method is supported");
       }
 
       if (settings.async) {


### PR DESCRIPTION
not throwing errors makes it really hard to debug -- no traceback means grepping for the string printed to stdout, which isn't even guaranteed to work.