### PR TITLE
Headers are case-insensitive — don't let Content-Type be overridden if written in an unusual case

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -348,7 +348,7 @@ exports.XMLHttpRequest = function() {
     } else if (data) {
       headers["Content-Length"] = Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
 
-      if (!headers["Content-Type"]) {
+      if (Object.keys(headers).reduce(function(key) { return key.toLowerCase() === 'content-type'; }).length === 0) {
         headers["Content-Type"] = "text/plain;charset=UTF-8";
       }
     } else if (settings.method === "POST") {


### PR DESCRIPTION
According to [RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", paragraph 4.2, "Message Headers" http headers are case insensitive](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2).

This became a problem for us as we use `node-XMLHttpRequest` in conjunction with [Fetch API](https://github.com/github/fetch/) and this change: https://github.com/github/fetch/issues/45 caused.