### PR TITLE
Trap missing response/headers in getAllResponseHeaders (fix for #27)

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -39,7 +39,7 @@ exports.XMLHttpRequest = function() {
   // Set some default headers
   var defaultHeaders = {
     "User-Agent": "node-XMLHttpRequest",
-    "Accept": "*/*",
+    "Accept": "*/*"
   };
 
   var headers = defaultHeaders;
@@ -224,7 +224,7 @@ exports.XMLHttpRequest = function() {
    * @return string A string with all response headers separated by CR+LF
    */
   this.getAllResponseHeaders = function() {
-    if (this.readyState < this.HEADERS_RECEIVED || errorFlag) {
+    if (this.readyState < this.HEADERS_RECEIVED || errorFlag || !response || !response.headers) {
       return "";
     }
     var result = "";
@@ -235,7 +235,7 @@ exports.XMLHttpRequest = function() {
         result += i + ": " + response.headers[i] + "\r\n";
       }
     }
-    return result.substr(0, result.length - 2);
+    return result.substr(0, result.length > 1? result.length - 2: 0);
   };
 
   /**


### PR DESCRIPTION
This is a work-around for issue #27 (Sync requests via jQuery fail).