### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "url": "http://driverdan.com"
   },
   "keywords": ["xhr", "ajax"],
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://creativecommons.org/licenses/MIT/"
-  }],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/driverdan/node-XMLHttpRequest.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/