### PR TITLE
Set default host on protocol==null

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -284,6 +284,7 @@ exports.XMLHttpRequest = function() {
         break;
 
       case undefined:
+      case null:
       case "":
         host = "localhost";
         break;


### PR DESCRIPTION
Some libraries set protocol to null instead of undefined, so we need to check for it here to allow default behaviour. Otherwise, we get the "Protocol not supported." error.
