### PR TITLE
Do not throw when there is no response

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -224,7 +224,7 @@ exports.XMLHttpRequest = function() {
    * @return string A string with all response headers separated by CR+LF
    */
   this.getAllResponseHeaders = function() {
-    if (this.readyState < this.HEADERS_RECEIVED || errorFlag) {
+    if (this.readyState < this.HEADERS_RECEIVED || errorFlag || !response) {
       return "";
     }
     var result = "";


### PR DESCRIPTION
This prevents an unexpected exception from being thrown when trying to get headers from a "file:" request.