### PR TITLE
Switch to localhost when protocol is null

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -284,6 +284,7 @@ exports.XMLHttpRequest = function() {
         break;
 
       case undefined:
+      case null:
       case "":
         host = "localhost";
         break;


### PR DESCRIPTION
In order to allow tests libs to work properly, we must handle the protocol when it's null or undefined.
