### PR TITLE
Consider null protocol as missing protocol, not an unsupported one.

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -284,6 +284,7 @@ exports.XMLHttpRequest = function() {
         break;
 
       case undefined:
+      case null:
       case "":
         host = "localhost";
         break;


### PR DESCRIPTION
When the URL is just a relative path, as in /blah/bleh, at least in v0.12.7, url.protocol is not set at all, thus, it’s null.