### PR TITLE
Configurable defaults

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -284,6 +284,7 @@ exports.XMLHttpRequest = function() {
         break;
 
       case undefined:
+      case null:
       case "":
         host = "localhost";
         break;

--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -15,6 +15,11 @@ var Url = require("url");
 var spawn = require("child_process").spawn;
 var fs = require("fs");
 
+exports.defaults = {
+  host: null,
+  port: null
+}
+
 exports.XMLHttpRequest = function() {
   "use strict";
 
@@ -286,7 +291,7 @@ exports.XMLHttpRequest = function() {
       case undefined:
       case null:
       case "":
-        host = "localhost";
+        host = exports.defaults.host || "localhost";
         break;
 
       default:
@@ -324,7 +329,7 @@ exports.XMLHttpRequest = function() {
 
     // Default to port 80. If accessing localhost on another port be sure
     // to use http://localhost:port/path
-    var port = url.port || (ssl ? 443 : 80);
+    var port = url.port || exports.defaults.port || (ssl ? 443 : 80);
     // Add query string if one is used
     var uri = url.pathname + (url.search ? url.search : "");
 


### PR DESCRIPTION
I'm working on universal JavaScript, that is, running the same JavaScript on the browser and the server for pre-rendering server side applications and on client applications it's normal to do xmlhttprequests with just a path. In this case this library assumes you'll be talking to http://localhost:80/, but that's not always the case, so I made it possible to set a default, to bootstrap an environment where the application can run unchanged.

I'll be publishing blog posts and libraries I developed around this idea at https://CarouselApps.com in case you are curious.