### PR TITLE
A request header's default value can now be overwritten.

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -8,6 +8,7 @@
  *
  * @author Dan DeFelippi <dan@driverdan.com>
  * @contributor David Ellis <d.f.ellis@ieee.org>
+ * @contributor Felipe Spinolo <felipespinolo@gmail.com>
  * @license MIT
  */
 
@@ -202,7 +203,11 @@ exports.XMLHttpRequest = function() {
     }
     header = headersCase[header.toLowerCase()] || header;
     headersCase[header.toLowerCase()] = header;
-    headers[header] = headers[header] ? headers[header] + ', ' + value : value;
+    if (headers[header] && headers[header] !== defaultHeaders[header]) { 
+        headers[header] = headers[header] + ', ' + value;
+    } else {
+        headers[header] = value;
+    }
   };
 
   /**


### PR DESCRIPTION
The default value of `*/*` for the `Accept` header can cause undesirable behavior.  For example, I am dealing with an API that can serve XML or JSON, but I cannot get it to return JSON due to the default value being first in the list.  This change makes it so that if the setRequestHeader is called on a header that is currently set to its default value, it will overwrite the value instead of appending to it.