### PR TITLE
getResponseHeader should work for non-lowercased response headers

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -216,10 +216,10 @@ exports.XMLHttpRequest = function() {
       && this.readyState > this.OPENED
       && response
       && response.headers
-      && response.headers[header.toLowerCase()]
+      && (response.headers[header.toLowerCase()] || response.headers[header])
       && !errorFlag
     ) {
-      return response.headers[header.toLowerCase()];
+      return (response.headers[header.toLowerCase()] || response.headers[header]);
     }
 
     return null;


### PR DESCRIPTION
Hi hi, since response headers are not always lowercased, this PR allows getResponseHeader to be used in those cases.