### PR TITLE
Make webpack browser compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
     "lib": "./lib",
     "example": "./example"
   },
-  "main": "./lib/XMLHttpRequest.js"
+  "main": "./lib/XMLHttpRequest.js",
+  "browser": {
+    "fs": false,
+    "child_process": false
+  }
 }


### PR DESCRIPTION
Tell webpack to mock fs and child_process when packaging for the browser.

This will fix #89 and is lighter-weight than #66 

See https://github.com/webpack/webpack/issues/744#issuecomment-72323760 for webpak contributors advice on how to solve, which this pr implements: 

"The proper course is [to] ask the module author to make the module browser compatible. The author can add browser: { fs: false, child_process: false } to the package.json to tell webpack that it's ok for the module to get an empty object for these modules."
