### PR TITLE
.abort: Don't set headers to default

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -111,7 +111,7 @@ exports.XMLHttpRequest = function() {
   this.responseXML = "";
   this.status = null;
   this.statusText = null;
-  
+
   // Whether cross-site Access-Control requests should be made using
   // credentials such as cookies or authorization headers
   this.withCredentials = false;
@@ -542,7 +542,7 @@ exports.XMLHttpRequest = function() {
       request = null;
     }
 
-    headers = defaultHeaders;
+    headers = {};
     this.status = 0;
     this.responseText = "";
     this.responseXML = "";

--- a/tests/test-headers.js
+++ b/tests/test-headers.js
@@ -61,7 +61,7 @@ try {
   // Invalid header
   xhr.setRequestHeader("Content-Length", 0);
   // Allowed header outside of specs
-  xhr.setRequestHeader("user-agent", "node-XMLHttpRequest-test");
+  xhr.setRequestHeader("User-Agent", "node-XMLHttpRequest-test");
   // Test getRequestHeader
   assert.equal("Foobar", xhr.getRequestHeader("X-Test"));
   assert.equal("Foobar", xhr.getRequestHeader("x-tEST"));


### PR DESCRIPTION
In `.abort()`, we were setting `headers` to `defaultHeaders`.  This causes a couple problems.

First, this means you can't set the full `User-Agent`.  Since `.open()` calls `this.abort()`, `User-Agent` will be set after the consumer calls `xhr.open(...)`.  If the consumer then calls `xhr.setRequestHeader("User-Agent", "foo");`, the actual `User-Agent` would end up as `node-XMLHttpRequest, foo` instead of just `foo` because `setRequestHeader()` appends to the existing value (set by `.abort()`) if it already exists.

The `test-headers.js` test actually sets `user-agent` to `node-XMLHttpRequest-test` and validates this, but it only works because it sets `user-agent` and not `User-Agent`.  Since `.abort()` was just calling `headers = defaultHeaders` without setting `headersCase` as well, the test headers ended up as:

```
{
  "User-Agent": "node-XMLHttpRequest",
  "user-agent": "node-XMLHttpRequest-test"
}
```

Which would send `node-XMLHttpRequest-test` over the wire since it was last.

To solve this, I think we can simply not set `headers = {}` in `.abort()`, as `.send()` will set the default headers later anyways.