### PR TITLE
Updated redirect code to set header host parameter, set doRequest for protocol change

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -408,6 +408,9 @@ exports.XMLHttpRequest = function() {
           var url = Url.parse(settings.url);
           // Set host var in case it's used later
           host = url.hostname;
+          // Set host parameter for header or redirect won't work
+          headers.Host = host;
+          
           // Options for the new request
           var newOptions = {
             hostname: url.hostname,
@@ -417,6 +420,11 @@ exports.XMLHttpRequest = function() {
             headers: headers,
             withCredentials: self.withCredentials
           };
+          
+          // Update ssl and doRequest to be appropriate 
+          // For (potentially) new protocol
+          ssl = (url.protocol == "https:" ? true : false);
+          doRequest = ssl ? https.request : http.request;
 
           // Issue the new request
           request = doRequest(newOptions, responseHandler).on("error", errorHandler);


### PR DESCRIPTION
The current redirect handler does not update the host parameter in the header, causing it to connect to the wrong host (at least on Windows), it also does not update the doRequest function in case of a change between http and https, which causes an infinite loop if you request sites that automatically switch to https (such as going to http://wikipedia.org).