### PR TITLE
rejectUnauthorized option for ssl issue

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -115,6 +115,7 @@ exports.XMLHttpRequest = function() {
   // Whether cross-site Access-Control requests should be made using
   // credentials such as cookies or authorization headers
   this.withCredentials = false;
+  this.rejectUnauthorized = false;
 
   /**
    * Private methods
@@ -378,7 +379,8 @@ exports.XMLHttpRequest = function() {
       method: settings.method,
       headers: headers,
       agent: false,
-      withCredentials: self.withCredentials
+      withCredentials: self.withCredentials,
+      rejectUnauthorized: self.rejectUnauthorized
     };
 
     // Reset error flag
@@ -415,7 +417,8 @@ exports.XMLHttpRequest = function() {
             path: url.path,
             method: response.statusCode === 303 ? "GET" : settings.method,
             headers: headers,
-            withCredentials: self.withCredentials
+            withCredentials: self.withCredentials,
+            rejectUnauthorized: self.rejectUnauthorized
           };
 
           // Issue the new request


### PR DESCRIPTION
if you want to make request with ssl may you get error message if your ssl service has a self signed certificate. You can fix this simple as below.

find : this.withCredentials = false;
insert new line after find: this.rejectUnauthorized = false;

find: withCredentials: self.withCredentials,
insert new line after find: rejectUnauthorized: self.rejectUnauthorized

find: withCredentials: self.withCredentials,
insert new line after find: rejectUnauthorized: self.rejectUnauthorized