### PR TITLE
Changes to enable the JSDO to use xmlhttprequest-cookie

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -15,7 +15,7 @@ var Url = require("url");
 var spawn = require("child_process").spawn;
 var fs = require("fs");
 
-exports.XMLHttpRequest = function() {
+exports.XMLHttpRequest = function XMLHttpRequest() {
   "use strict";
 
   /**
@@ -542,7 +542,14 @@ exports.XMLHttpRequest = function() {
       request = null;
     }
 
-    headers = defaultHeaders;
+    headers = {};
+    for (var name in defaultHeaders) {
+      headers[name] = defaultHeaders[name];
+    }    
+    // Remove Accept header so that it can be set via setRequestHeader(),
+    // otherwise, setRequestHeader() would append to it.
+    delete headers["Accept"];
+
     this.status = 0;
     this.responseText = "";
     this.responseXML = "";


### PR DESCRIPTION
When working with the xmlhttprequest-cookie library, objects created using the wrapper are not recognized as instances of XMLHttpRequest. (instanceof XMLHttpRequest).
Specified "XMLHttpRequest" as the function name so that code can check for constructor.name.

The new behavior is consistent with web browser behavior where constructor.name for an XHR object is set.

When working with FORM-based authentication from the JSDO.
The Accept header always includes "*/*" because it is listed in the defaultHeaders variable.
Code in the JSDOSession expects to be able to set the Accept header to "application/json".
Changed line 545 to copy defaultHeaders to the headers variable and then delete the "Accept" property so that it can be set by calling setRequestHeader(). If the Accept header is not specified, then code in line 337 ensures that it is set to the default: "*/*".

The new behavior is consistent with web browser behavior where the Accept header is not set by default.
See:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader