### PR TITLE
Add xhr.response for 'arraybuffer' responseType.

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -109,6 +109,7 @@ exports.XMLHttpRequest = function() {
   // Result & response
   this.responseText = "";
   this.responseXML = "";
+  this.response = Buffer.alloc(0);
   this.status = null;
   this.statusText = null;
   
@@ -434,6 +435,7 @@ exports.XMLHttpRequest = function() {
           // Make sure there's some data
           if (chunk) {
             self.responseText += chunk;
+            self.response = Buffer.concat([self.response, chunk]);
           }
           // Don't emit state changes if the connection has been aborted.
           if (sendFlag) {


### PR DESCRIPTION
The responseType property of the XMLHttpRequest object can be set to change the expected response type from the server.

This patch can receive binary data from server with xhr.response.

for more details about sending and receiving binary data.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data