### PR TITLE
Write temp files to /tmp

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -472,8 +472,8 @@ exports.XMLHttpRequest = function() {
       self.dispatchEvent("loadstart");
     } else { // Synchronous
       // Create a temporary file for communication with the other Node process
-      var contentFile = ".node-xmlhttprequest-content-" + process.pid;
-      var syncFile = ".node-xmlhttprequest-sync-" + process.pid;
+      var contentFile = "/tmp/node-xmlhttprequest-content-" + process.pid;
+      var syncFile = "/tmp/node-xmlhttprequest-sync-" + process.pid;
       fs.writeFileSync(syncFile, "", "utf8");
       // The async request the other Node process executes
       var execString = "var http = require('http'), https = require('https'), fs = require('fs');"


### PR DESCRIPTION
As suggested by @lucabarze in https://github.com/driverdan/node-XMLHttpRequest/issues/145 this fix should fix the problem we have when using sync requests on AWS Lambda.