### PR TITLE
Use console.log() instead of util.puts()

### DIFF
--- a/example/demo.js
+++ b/example/demo.js
@@ -1,14 +1,13 @@
-var sys = require('util');
 var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
 
 var xhr = new XMLHttpRequest();
 
 xhr.onreadystatechange = function() {
-	sys.puts("State: " + this.readyState);
+	console.log("State: " + this.readyState);
 	
 	if (this.readyState === 4) {
-		sys.puts("Complete.\nBody length: " + this.responseText.length);
-		sys.puts("Body:\n" + this.responseText);
+		console.log("Complete.\nBody length: " + this.responseText.length);
+		console.log("Body:\n" + this.responseText);
 	}
 };
 


### PR DESCRIPTION
Since https://github.com/nodejs/node/commit/896b2aa7074fc886efd7dd0a397d694763cac7ce (included in v0.11.3), `util.puts()` becomes [deprecated API](https://nodejs.org/api/deprecations.html#deprecations_dep0027_util_puts). This pull-request uses `console.log` instead of `util.puts`.

## Before pull-request

```sh
$ node demo.js
State: 1
State: 1
(node:29751) [DEP0027] DeprecationWarning: util.puts is deprecated. Use console.log instead.
State: 2
State: 3
State: 4
Complete.
Body length: 10959
Body:
<!doctype html>
<!--
HTML5 Boilerplate! AAAAAAAAAAWWWWWW YYYYYYEEEEEEEEAAAAAAAA!
...
```

## After pull-request

```sh
$ node demo.js
State: 1
State: 1
State: 2
State: 3
State: 3
State: 4
Complete.
Body length: 10959
Body:
<!doctype html>
<!--
HTML5 Boilerplate! AAAAAAAAAAWWWWWW YYYYYYEEEEEEEEAAAAAAAA!
...
```
