### PR TITLE
Fix file collision when running in workers.

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -14,6 +14,7 @@
 var Url = require("url");
 var spawn = require("child_process").spawn;
 var fs = require("fs");
+var uuid = require("uuid")
 
 exports.XMLHttpRequest = function() {
   "use strict";
@@ -476,8 +477,9 @@ exports.XMLHttpRequest = function() {
       self.dispatchEvent("loadstart");
     } else { // Synchronous
       // Create a temporary file for communication with the other Node process
-      var contentFile = ".node-xmlhttprequest-content-" + process.pid;
-      var syncFile = ".node-xmlhttprequest-sync-" + process.pid;
+      var uniqueId = process.pid + "-" + uuid.v4();
+      var contentFile = ".node-xmlhttprequest-content-" + uniqueId;
+      var syncFile = ".node-xmlhttprequest-sync-" + uniqueId;
       fs.writeFileSync(syncFile, "", "utf8");
       // The async request the other Node process executes
       var execString = "var http = require('http'), https = require('https'), fs = require('fs');"

--- a/package.json
+++ b/package.json
@@ -1,18 +1,24 @@
 {
   "name": "xmlhttprequest",
   "description": "XMLHttpRequest for Node",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "author": {
     "name": "Dan DeFelippi",
     "url": "http://driverdan.com"
   },
-  "keywords": ["xhr", "ajax"],
+  "keywords": [
+    "xhr",
+    "ajax"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/driverdan/node-XMLHttpRequest.git"
   },
-  "browser": "./lib/browser.js",
+  "browser": {
+    "fs": false,
+    "child_process": false
+  },
   "bugs": "http://github.com/driverdan/node-XMLHttpRequest/issues",
   "engines": {
     "node": ">=0.4.0"
@@ -22,8 +28,7 @@
     "example": "./example"
   },
   "main": "./lib/XMLHttpRequest.js",
-  "browser": {
-    "fs": false,
-    "child_process": false
+  "dependencies": {
+    "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
In [XMLHttpRequest.js lines 479-480](https://github.com/driverdan/node-XMLHttpRequest/blob/97966e4ca1c9f2cc5574d8775cbdacebfec75455/lib/XMLHttpRequest.js#L479-480
), two filenames are defined using process.pid as a unique key.
```
      var contentFile = ".node-xmlhttprequest-content-" + process.pid;
      var syncFile = ".node-xmlhttprequest-sync-" + process.pid;
```
However, when running in workers this is not enough, due to the fact that the process.pid is the same across workers. This causes a filename collision.

Appending a UUID to the key fixes the problem.
```
      var uniqueId = process.pid + "-" + uuid.v4();
      var contentFile = ".node-xmlhttprequest-content-" + uniqueId;
      var syncFile = ".node-xmlhttprequest-sync-" + uniqueId;
```