### PR TITLE
Populate XHR response property with binary data

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -109,6 +109,7 @@ exports.XMLHttpRequest = function() {
   // Result & response
   this.responseText = "";
   this.responseXML = "";
+  this.response = Buffer.alloc(0);
   this.status = null;
   this.statusText = null;
 
@@ -429,7 +430,7 @@ exports.XMLHttpRequest = function() {
           return;
         }
 
-        response.setEncoding("utf8");
+        response.setEncoding('binary');
 
         setState(self.HEADERS_RECEIVED);
         self.status = response.statusCode;
@@ -437,7 +438,9 @@ exports.XMLHttpRequest = function() {
         response.on("data", function(chunk) {
           // Make sure there's some data
           if (chunk) {
-            self.responseText += chunk;
+            var data = Buffer.from(chunk, 'binary');
+            self.responseText += data.toString('utf8');
+            self.response = Buffer.concat([self.response, data]);
           }
           // Don't emit state changes if the connection has been aborted.
           if (sendFlag) {
@@ -484,13 +487,16 @@ exports.XMLHttpRequest = function() {
         + "var doRequest = http" + (ssl ? "s" : "") + ".request;"
         + "var options = " + JSON.stringify(options) + ";"
         + "var responseText = '';"
+        + "var responseData = Buffer.alloc(0);"
         + "var req = doRequest(options, function(response) {"
-        + "response.setEncoding('utf8');"
+        + "response.setEncoding('binary');"
         + "response.on('data', function(chunk) {"
-        + "  responseText += chunk;"
+        + "  var data = Buffer.from(chunk, 'binary');"
+        + "  responseText += data.toString('utf8');"
+        + "  responseData = Buffer.concat([responseData, data]);"
         + "});"
         + "response.on('end', function() {"
-        + "fs.writeFileSync('" + contentFile + "', JSON.stringify({err: null, data: {statusCode: response.statusCode, headers: response.headers, text: responseText}}), 'utf8');"
+        + "fs.writeFileSync('" + contentFile + "', JSON.stringify({err: null, data: {statusCode: response.statusCode, headers: response.headers, text: responseText, data: responseData.toString('base64')}}), 'utf8');"
         + "fs.unlinkSync('" + syncFile + "');"
         + "});"
         + "response.on('error', function(error) {"
@@ -520,6 +526,7 @@ exports.XMLHttpRequest = function() {
         response = resp.data;
         self.status = resp.data.statusCode;
         self.responseText = resp.data.text;
+        self.response = Buffer.from(resp.data.data, 'base64');
         setState(self.DONE);
       }
     }


### PR DESCRIPTION
Always populating `response` is a hack (one should really request it via `responseType`), but a useful one. For my particular use case I wanted to do a synchronous XHR, in a worker thread, returning a binary data response back. It turned out to be surprisingly difficult to get all three requirements working at once with the various packages that I tried.

This PR is similar to the solution in #155, populating `response` using `Buffer.concat`, but with some further improvements.

By setting `response.setEncoding('binary')`, the received data is not lossy encoded to 'utf8' before being stored in the response Buffer. This fixes a problem that exists even in #155 where certain bytes are incorrectly converted in the response buffer, irreversibly becoming 0xFD.

Since the default encoding is now binary, the response data is explicitly encoded to utf8 when storing it in `responseText`, maintaining the default behaviour of the module before the change.

The same changes are made to the synchronous version of the code. Since part of this process is for data to be temporarily written out to a file, the data buffer is written out base64 encoded here to avoid the same issues with utf8 encoding/decoding when loading the data back in from the file.
